### PR TITLE
Fix CITATION.cff interaction with GitHub 

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -57,8 +57,8 @@ preferred-citation:
     alias: "ICPP 2017"
     country: "GB"
     city: "Bristol"
-    date-start: "2017-08-14"
-    date-end: "2017-08-17"
+    date-start: 2017-08-14
+    date-end: 2017-08-17
     website: "https://www.icpp-conf.org/2017/"
   publisher:
     name: "IEEE"


### PR DESCRIPTION
This fixes GitHub's handling of the CITATION.cff file. When including the
quotes, the cite button becomes unresponsive and a 500 is returned when viewing
the CITATION.cff file. Strangly, cffconvert --validate didn't flag any issues.